### PR TITLE
Adding PIE load_addr support

### DIFF
--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -855,8 +855,7 @@ class Tracer(object):
 
     def _set_linux_simprocedures(self, project):
         for symbol in self.simprocedures:
-            project.set_sim_procedure(
-                    project.loader.main_bin,
+            project.hook_symbol(
                     symbol,
                     self.simprocedures[symbol])
 

--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -258,6 +258,7 @@ class Tracer(object):
                     # if so we need to take special care
                     r_plt = self._p.loader.main_bin.reverse_plt
                     if current.addr not in self._resolved \
+                            and self.previous is not None \
                             and self.previous.addr in r_plt:
                         self.bb_cnt += 2
                         self._resolved.add(current.addr)
@@ -1054,7 +1055,7 @@ class Tracer(object):
 
         self.remove_options |= so.simplification
         self.add_options |= options
-        entry_state = project.factory.entry_state(
+        entry_state = project.factory.full_init_state(
                 fs=fs,
                 concrete_fs=True,
                 chroot=self.chroot,

--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -1030,7 +1030,11 @@ class Tracer(object):
         prepare the initial paths for Linux binaries
         '''
 
-        project = angr.Project(self.binary,load_options={'main_opts': {'custom_base_addr': self.qemu_base_addr }})
+        # Only requesting custom base if this is a PIE
+        if self._p.loader.main_bin.pic:
+            project = angr.Project(self.binary,load_options={'main_opts': {'custom_base_addr': self.qemu_base_addr }})
+        else:
+            project = angr.Project(self.binary)
 
         if not self.crash_mode:
             self._set_linux_simprocedures(project)


### PR DESCRIPTION
When playing with tracer, i noticed it would not successfully trace a PIE compiled binary. Turns out, there's a mismatch between the base address that angr will by default load at and the base address that QEMU loads at.

Luckily, that base address is displayed in the default QEMU output that is created when you run the dynamic trace. Basically, what I'm adding is to pull that value out, then use it when you create your initial path group. In the case of normal non-PIE binaries the functionality should be the same as currently. However, in PIE, it seems best to find the value QEMU displays and use that, since the chosen base address may vary from QEMU installs or versions. It also warns the user if this is the case.

An example PIE (vulnerable) binary is attached. The actually binary doesn't matter that much, just an example.

[a.zip](https://github.com/angr/tracer/files/681761/a.zip)

An example of what doesn't work currently but should in the patch is:

```python
import  tracer
t = tracer.Tracer("./a.out","A")
t.next_branch()
```