### PR TITLE
Changing step to full step

### DIFF
--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -334,7 +334,8 @@ class Tracer(object):
                 current.trim_history()
 
             self.prev_path_group = self.path_group
-            self.path_group = self.path_group.step(size=bbl_max_bytes)
+            self.path_group = self.path_group.step()
+
             if self.crash_type == EXEC_STACK:
                 self.path_group = self.path_group.stash(from_stash='active',
                         to_stash='crashed')


### PR DESCRIPTION
Honestly not sure this is the right answer since I'm not sure why bbl_max_bytes is being used here. The problem I've been having is with a position independent executable. For some reason, with the step here utilizing the size parameter, tracer would actually throw a pyVEX error:

```python
simuvex.s_errors.SimTranslationError('Translation error',
                                     pyvex.errors.PyVEXError,
                                     pyvex.errors.PyVEXError('libvex: unknown error'))
```

When I change the step to just be a full step everything works. Similarly, if I ask angr to symbolically explore the binary things work just fine.

Attaching the example binary:

[a.zip](https://github.com/angr/tracer/files/705788/a.zip)
