### PR TITLE
Added environment variable support for tracing via qemu

### DIFF
--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -742,7 +742,8 @@ class Tracer(object):
                         args,
                         stdin=subprocess.PIPE,
                         stdout=stdout_f,
-                        stderr=devnull)
+                        stderr=devnull,
+                        env=os.environ)
                 _, _ = p.communicate(self.input)
             else:
                 l.info("tracing as pov file")
@@ -751,7 +752,8 @@ class Tracer(object):
                         args,
                         stdin=in_s,
                         stdout=stdout_f,
-                        stderr=devnull)
+                        stderr=devnull,
+                        env=os.environ)
                 for write in self.pov_file.writes:
                     out_s.send(write)
                     time.sleep(.01)


### PR DESCRIPTION
Patched in environment variable support for the call to qemu.  This allows the caller to do things like set LD_PRELOAD before tracing.  In some cases this is required in order to run the target binary.  This addresses the issue raised when attempting to run Driller (https://github.com/shellphish/driller/issues/22)