### PR TITLE
Allow empty exclude_sim_procedures_list argument

### DIFF
--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -91,7 +91,7 @@ class Tracer(object):
         self.simprocedures = {} if simprocedures is None else simprocedures
         self._hooks = {} if hooks is None else hooks
         self.input_max_size = max_size or len(input)
-        self.exclude_sim_procedures_list = ["malloc","free","calloc","realloc"] if exclude_sim_procedures_list is None else exclude_sim_procedures_list 
+        self.exclude_sim_procedures_list = ["malloc","free","calloc","realloc"] if exclude_sim_procedures_list is None else exclude_sim_procedures_list
         self.argv = argv or [binary]
 
         for h in self._hooks:

--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -91,7 +91,7 @@ class Tracer(object):
         self.simprocedures = {} if simprocedures is None else simprocedures
         self._hooks = {} if hooks is None else hooks
         self.input_max_size = max_size or len(input)
-        self.exclude_sim_procedures_list = exclude_sim_procedures_list or ["malloc","free","calloc","realloc"]
+        self.exclude_sim_procedures_list = [] if exclude_sim_procedures_list is None else exclude_sim_procedures_list 
         self.argv = argv or [binary]
 
         for h in self._hooks:

--- a/tracer/tracer.py
+++ b/tracer/tracer.py
@@ -91,7 +91,7 @@ class Tracer(object):
         self.simprocedures = {} if simprocedures is None else simprocedures
         self._hooks = {} if hooks is None else hooks
         self.input_max_size = max_size or len(input)
-        self.exclude_sim_procedures_list = [] if exclude_sim_procedures_list is None else exclude_sim_procedures_list 
+        self.exclude_sim_procedures_list = ["malloc","free","calloc","realloc"] if exclude_sim_procedures_list is None else exclude_sim_procedures_list 
         self.argv = argv or [binary]
 
         for h in self._hooks:


### PR DESCRIPTION
This makes it possible to specify an empty list for exclude_sim_procedures_list argument, which wasn't previously possible as `[] or ['foo']` evaluates to `['foo']`. I'm not entirely sure why *alloc/free are banned by default, but have left that be.