### PR TITLE
some fix

### DIFF
--- a/tracer/qemu_runner.py
+++ b/tracer/qemu_runner.py
@@ -320,6 +320,11 @@ class QEMURunner:
                     shutil.copy(core_glob[0], core_target)
             except subprocess.TimeoutExpired:
                 r['process'].terminate()
+                r['returncode'] = r['process'].wait()
+                if record_trace and 'trace' not in r:
+                    r['trace'] = b''
+                if record_magic and 'magic' not in r:
+                    r['magic'] = b''
                 r['timeout'] = True
 
         return r

--- a/tracer/qemu_runner.py
+++ b/tracer/qemu_runner.py
@@ -156,7 +156,7 @@ class QEMURunner:
             self._exec_func = exec_func
 
         if record_stdout:
-            tmp = tempfile.mktemp(prefix="stdout_" + os.path.basename(self._p.filename))
+            tmp = tempfile.mkstemp(prefix="stdout_" + os.path.basename(self._p.filename))[1]
             # will set crash_mode correctly
             self._run(stdout_file=tmp)
             with open(tmp, "rb") as f:
@@ -246,7 +246,7 @@ class QEMURunner:
     @staticmethod
     @contextlib.contextmanager
     def _tmpfile(**kwargs):
-        tmpfile = tempfile.mktemp(**kwargs)
+        tmpfile = tempfile.mkstemp(**kwargs)[1]
         try:
             yield tmpfile
         finally:
@@ -266,7 +266,7 @@ class QEMURunner:
 
             # record the trace, if we want to
             if record_trace:
-                trace_filename = tempfile.mktemp(dir="/dev/shm/", prefix="tracer-log-")
+                trace_filename = tempfile.mkstemp(dir="/dev/shm/", prefix="tracer-log-")[1]
                 cmd_args += ["-d", "exec", "-D", trace_filename]
             else:
                 trace_filename = None
@@ -274,7 +274,7 @@ class QEMURunner:
 
             # If the binary is CGC we'll also take this opportunity to read in the magic page.
             if record_magic:
-                magic_filename = tempfile.mktemp(dir="/dev/shm/", prefix="tracer-magic-")
+                magic_filename = tempfile.mkstemp(dir="/dev/shm/", prefix="tracer-magic-")[1]
                 cmd_args += ["-magicdump", magic_filename]
             else:
                 magic_filename = None

--- a/tracer/qemu_runner.py
+++ b/tracer/qemu_runner.py
@@ -232,19 +232,6 @@ class QEMURunner:
 
     @staticmethod
     @contextlib.contextmanager
-    def _cd_tmpdir():
-        curdir = os.getcwd()
-        tmpdir = tempfile.mkdtemp(prefix="/tmp/tracer_")
-        try:
-            os.chdir(tmpdir)
-            yield tmpdir
-        finally:
-            os.chdir(curdir)
-            with contextlib.suppress(FileNotFoundError):
-                 shutil.rmtree(tmpdir)
-
-    @staticmethod
-    @contextlib.contextmanager
     def _tmpfile(**kwargs):
         tmpfile = tempfile.mkstemp(**kwargs)[1]
         try:
@@ -257,7 +244,7 @@ class QEMURunner:
     def _exec_func(self, qemu_variant, qemu_args, program_args, ld_path=None, stdin=None, stdout=None, stderr=None, record_trace=True, record_magic=False, core_target=None): #pylint:disable=method-hidden
         #pylint:disable=subprocess-popen-preexec-fn
 
-        with self._cd_tmpdir() as tmpdir, self._tmpfile(dir="/dev/shm/", prefix="tracer-log-") as trace_filename, self._tmpfile(dir="/dev/shm/", prefix="tracer-magic-") as magic_filename, contextlib.ExitStack() as exit_stack:
+        with self._tmpfile(dir="/dev/shm/", prefix="tracer-log-") as trace_filename, self._tmpfile(dir="/dev/shm/", prefix="tracer-magic-") as magic_filename, contextlib.ExitStack() as exit_stack:
             cmd_args = [ qemu_variant ]
             cmd_args += qemu_args
 
@@ -314,10 +301,12 @@ class QEMURunner:
                     with open(magic_filename, 'rb') as tf:
                         r['magic'] = tf.read()
 
-                # save the core
-                core_glob = glob.glob(os.path.join(tmpdir, "qemu_"+os.path.basename(program_args[0])+"_*.core"))
+                # save the core and clean up the original core
+                core_glob = glob.glob("/tmp/qemu_"+os.path.basename(program_args[0])+"_*.core")
                 if core_target and core_glob:
                     shutil.copy(core_glob[0], core_target)
+                if core_glob:
+                    os.unlink(core_glob[0])
             except subprocess.TimeoutExpired:
                 r['process'].terminate()
                 r['returncode'] = r['process'].wait()


### PR DESCRIPTION
1. use `mkstemp` instead of `mktemp`.
According to https://docs.python.org/3/library/tempfile.html, `mktemp` is already deprecated. And somehow it does not create files and raise an error on my computer.

2. attempt to fix issues related to relative path.

3. initialize the information we may access later.
I'm not sure how we should initialize it actually.